### PR TITLE
Add "become: yes" if other user than root is used

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 # handlers file for adriagalin.timezone
 - name: update tzdata
   command: dpkg-reconfigure --frontend noninteractive tzdata
+  become: yes


### PR DESCRIPTION
I use this role but I don't use root user in my script.:

- hosts: servers
      roles:
         - { role: adriagalin.timezone, become: yes }

So, I need to add: "become: yes" directive on the handler to make it work

It doesn't change anything with root user usage