### PR TITLE
Bump version to 2.0.0, require Ansible 2.4+, fix deprecation warnings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 2.0.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ script:
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
 
   # Run the role/playbook with ansible-playbook.
-  - ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo -vvvv
+  - ansible-playbook -i tests/inventory tests/test.yml --connection=local --become -vvvv
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
-    ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo
+    ansible-playbook -i tests/inventory tests/test.yml --connection=local --become
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ sudo: required
 
 env:
   - ANSIBLE_VERSION=latest
-  - ANSIBLE_VERSION=2.0
-  - ANSIBLE_VERSION=1.9.6
+  - ANSIBLE_VERSION=2.4.3
 
 branches:
   only:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,3 +5,7 @@
 - Add webhook and update env versions in travis config file
 - Update ansible min version in meta.yml file
 - Update readme
+
+2.0.0
+- Breaking change: now requires Ansible 2.4+
+- Fixes deprecation warnings for Ansible 2.4+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Should work with:
 -	All Ubuntu
 -	All Debian
 
+Ansible compatibility:
+
+- Use role v1.0.1 for Ansible < 2.4
+- Use role v2.0.0 for Ansible 2.4+ (to avoid warnings)
+
 Role Variables
 --------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install and set timezone on your systems.
   company: Adria Galin
   license: GPLv3
-  min_ansible_version: 1.9
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # tasks file for adriagalin.timezone
-- include: install.yml
+- import_tasks: install.yml
   tags: [ common, timezone ]
 
-- include: timezone.yml
+- import_tasks: timezone.yml
   tags: [ common, timezone ]
   
-- include: localtime.yml
+- import_tasks: localtime.yml
   tags: [ common, timezone, localtime ]


### PR DESCRIPTION
In this PR:

- Set required version of Ansible to 2.4+ (breaking change)
- Remove all deprecation warnings
- Bump version to 2.0.0 to indicate breaking change

This mimics what has been done [here](https://github.com/Yannik/ansible-role-relaymail/pull/7#issuecomment-364742557).