### PR TITLE
Fix documentation on how to use the role

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example Playbook
 ```yaml
     - hosts: servers
       roles:
-         - { role: adriagalin.timezone }
+         - { role: ansible.timezone }
 ```
 
 License


### PR DESCRIPTION
I tried to use the role and realized that the name is actually `ansible.timezone`.